### PR TITLE
Update doc string for differentiate

### DIFF
--- a/src/main/clojure/numeric/expresso/core.clj
+++ b/src/main/clojure/numeric/expresso/core.clj
@@ -244,6 +244,9 @@
   "Differentiates the given expression regarding the symbols in the symbol
    vector symbv
    example:
+   (differentiate '[x] (ex (* (** x 3) (* 3 x))))
+   ;=> (* 12 (** x 3))
+   To differentiate twice:
    (differentiate '[x x] (ex (* (** x 3) (* 3 x))))
    ;=> (* 36 (** x 2))"
   [symbv expr]


### PR DESCRIPTION
Make clear what '[x x] means by adding an example for taking the first derivative and explicitly mentioning '[x x] is meant to differentiate twice.
