### PR TITLE
update to clojure 1.11.1 and update expresso version to 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This are the key objectives:
 
 Add the following line to your leiningen dependencies:
 ```clojure
-[expresso "0.2.2"]
+[expresso "0.2.3"]
 ```
 For an in-depth tutorial and showcase of expresso, see the [expresso tutorial](https://github.com/mschuene/expresso-tutorial)
 ### Defining expressions

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
  	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  	<modelVersion>4.0.0</modelVersion>
  	<artifactId>expresso</artifactId>
- 	<version>0.2.2</version>
+ 	<version>0.2.3</version>
  
  	<parent>
  		<groupId>net.mikera</groupId>

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject expresso "0.2.2"
+(defproject expresso "0.2.3"
   :description "a general Algebraic Expression manipulation library in clojure"
   :url "https://github.com/clojure-numerics/expresso"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/mit-license.php"}
   :profiles {:dev {:dependencies [[org.clojure/tools.trace "0.7.8"]
                                   [criterium "0.4.3"]]}}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [instaparse "1.4.5"]
                  [net.mikera/core.matrix "0.59.0"]
                  [org.clojure/core.memoize "0.5.8"]

--- a/src/main/clojure/numeric/expresso/construct.clj
+++ b/src/main/clojure/numeric/expresso/construct.clj
@@ -138,6 +138,7 @@
 (defmethod expresso-name 'clojure.core/+ [_] '+)
 (defmethod expresso-name 'clojure.core/- [_] '-)
 (defmethod expresso-name 'clojure.core// [_] '/)
+(defmethod expresso-name 'clojure.core/abs [_] 'abs)
 (defmethod expresso-name `= [_] '=)
 (defmethod expresso-name 'numeric.expresso.core/** [_] '**)
 (defmethod expresso-name `mop/* [_] '*)


### PR DESCRIPTION
I was getting an error : **java.lang.RuntimeException: Unable to resolve symbol: pos-int?**

expresso is using clojure 1.8.0 and pos-int? was added in clojure 1.9.0.
